### PR TITLE
add visibility attribute to XCProject

### DIFF
--- a/Source/Main/XCProject.h
+++ b/Source/Main/XCProject.h
@@ -22,6 +22,7 @@
 @class XCBuildConfigurationList;
 
 
+__attribute__((__visibility__("default")))
 @interface XCProject : NSObject {
 
 @private


### PR DESCRIPTION
Me again. Basically, this is a compile/link-time change, to allow obj-c++ programs to link against xcode-editor when -fvisibility=hidden is set as a CFLAG (to reduce binary size/load time -- http://gcc.gnu.org/wiki/Visibility).

Thanks again.
