### PR TITLE
Removes OCLogTemplate.h import.

### DIFF
--- a/Source/Main/XCBuildConfiguration.m
+++ b/Source/Main/XCBuildConfiguration.m
@@ -16,7 +16,6 @@
 #import "XCKeyBuilder.h"
 #import "XCProject.h"
 #import "XCSourceFile.h"
-#import "OCLogTemplate.h"
 
 @implementation XCBuildConfiguration
 
@@ -143,13 +142,13 @@
     NSDictionary* settings = [NSDictionary dictionaryWithObject:setting forKey:key];
     [self addBuildSettings:settings];
 
-    LogDebug(@"$$$$$$$$$$$ before: %@", [_project.objects objectForKey:_key]);
+    NSLog(@"$$$$$$$$$$$ before: %@", [_project.objects objectForKey:_key]);
 
     NSMutableDictionary* dict = [[[_project objects] objectForKey:_key] mutableCopy];
     [dict setValue:_buildSettings forKey:@"buildSettings"];
     [_project.objects setValue:dict forKey:_key];
 
-    LogDebug(@"The settings: %@", [_project.objects objectForKey:_key]);
+    NSLog(@"The settings: %@", [_project.objects objectForKey:_key]);
 
     }
 


### PR DESCRIPTION
Looks like all of the other references to OCLogTemplate.h were removed. This should fix the build.
