### PR TITLE
Move import of CommonDigest.h to allow building as framework

### DIFF
--- a/Source/Utils/XCKeyBuilder.h
+++ b/Source/Utils/XCKeyBuilder.h
@@ -11,13 +11,14 @@
 
 
 #import <Foundation/Foundation.h>
-#import <CommonCrypto/CommonDigest.h>
+
 
 #define HASH_VALUE_STORAGE_SIZE 48
+#define MD5_DIGEST_LENGTH 16
 
 typedef struct
 {
-    char value[CC_MD5_DIGEST_LENGTH];
+    char value[MD5_DIGEST_LENGTH];
 } HashValueMD5Hash;
 
 

--- a/Source/Utils/XCKeyBuilder.m
+++ b/Source/Utils/XCKeyBuilder.m
@@ -10,6 +10,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #import "XCKeyBuilder.h"
+#import <CommonCrypto/CommonDigest.h>
+
+#if MD5_DIGEST_LENGTH != CC_MD5_DIGEST_LENGTH
+#error Digest length in XCKeyBuilder.h (MD5_DIGEST_LENGTH) disagress with CommonCrypto value (CC_MD5_DIGEST_LENGTH)
+#endif
 
 @implementation XCKeyBuilder
 

--- a/Source/XCProject.m
+++ b/Source/XCProject.m
@@ -68,7 +68,7 @@
     {
         if ([[obj valueForKey:@"isa"] xce_hasFileReferenceType])
         {
-            XcodeSourceFileType fileType = XCSourceFileTypeFromStringRepresentation([obj valueForKey:@"lastKnownFileType"]);
+            XcodeSourceFileType fileType = XCSourceFileTypeFromStringRepresentation([obj valueForKey:@"lastKnownFileType"] ?: [obj valueForKey:@"explicitFileType"]);
             NSString* path = [obj valueForKey:@"path"];
             NSString* sourceTree = [obj valueForKey:@"sourceTree"];
             XCSourceFile* sourceFile = [XCSourceFile sourceFileWithProject:self
@@ -88,7 +88,7 @@
     NSDictionary* obj = [[self objects] valueForKey:key];
     if (obj && [[obj valueForKey:@"isa"] xce_hasFileReferenceOrReferenceProxyType])
     {
-        XcodeSourceFileType fileType = XCSourceFileTypeFromStringRepresentation([obj valueForKey:@"lastKnownFileType"]);
+        XcodeSourceFileType fileType = XCSourceFileTypeFromStringRepresentation([obj valueForKey:@"lastKnownFileType"]?: [obj valueForKey:@"explicitFileType"]);
 
         NSString* name = [obj valueForKey:@"name"];
         NSString* sourceTree = [obj valueForKey:@"sourceTree"];

--- a/Source/XcodeSourceFileType.h
+++ b/Source/XcodeSourceFileType.h
@@ -23,13 +23,19 @@ typedef NS_OPTIONS(NSInteger, XcodeSourceFileType)
     XibFile = 7,                 // .xib
     ImageResourcePNG = 8,        // .png
     Bundle = 9,                  // .bundle  .octet
-    Archive = 10,                 // .a files
-    HTML = 11,                    // HTML file
-    TEXT = 12,                    // Some text file
-    XcodeProject = 13,            // .xcodeproj
-    Folder = 14,                  // a Folder reference
-    AssetCatalog = 15,            // Assets
-    SourceCodeSwift = 16          // .swift
+    Archive = 10,                // .a files
+    HTML = 11,                   // HTML file
+    TEXT = 12,                   // Some text file
+    XcodeProject = 13,           // .xcodeproj
+    Folder = 14,                 // a Folder reference
+    AssetCatalog = 15,           // Assets
+    SourceCodeSwift = 16,        // .swift
+    Application = 17,            // .app (wrapper.application)
+    Playground = 18,             // .playground (file.playground)
+    ShellScript = 19,            // no suffix Xcode seems to detect (text.script.sh)
+    Markdown = 20,               // .md (net.daringfileball.markdown)
+    XMLPropertyList = 21,        // .plist (text.plist.xml)
+    Storyboard = 22              // .storyboard (file.storyboard)
 };
 
 NSString* NSStringFromXCSourceFileType(XcodeSourceFileType type);

--- a/Source/XcodeSourceFileType.m
+++ b/Source/XcodeSourceFileType.m
@@ -35,7 +35,14 @@ static NSDictionary* NSDictionaryWithXCFileReferenceTypes()
             @"wrapper.pb-project"    : @(XcodeProject),
             @"folder"                : @(Folder),
             @"folder.assetcatalog"   : @(AssetCatalog),
-            @"sourcecode.swift"     : @(SourceCodeSwift)
+            @"sourcecode.swift"      : @(SourceCodeSwift),
+            @"wrapper.application"   : @(Application),
+            @"file.playground"       : @(Playground),
+            @"text.script.sh"        : @(ShellScript),
+            @"net.daringfireball.markdown" : @(Markdown),
+            @"text.plist.xml"        : @(XMLPropertyList),
+            @"file.storyboard"       : @(Storyboard)
+            
         };
     });
 


### PR DESCRIPTION
I wanted to use XcodeEditor from Swift so I was using `use_frameworks!` in my `Podfile`. This causes a problem compiling `XCKeyBuilder.h`.  For reasons best known to them, Apple do not include a `module.map` for `CommonCrypto` and this causes the error below.
```
Include of non-modular header inside framework module 'XcodeEditor.XCKeyBuilder'
```
This pull request works around the error by moving the import into the .m file and defining a macro for the digest length.
