### PR TITLE
Add Xcode 7 lightweight generics to make Swift use easier

### DIFF
--- a/Source/XCGroup.h
+++ b/Source/XCGroup.h
@@ -21,6 +21,7 @@
 @class XCFrameworkDefinition;
 @class XCSourceFileDefinition;
 @class XCSubProjectDefinition;
+@class XCTarget;
 
 
 /**
@@ -68,14 +69,14 @@
 /**
  * An array containing the groups members as `XcodeGroupMember` types.
 */
-@property(nonatomic, strong, readonly) NSMutableArray* children;
+@property(nonatomic, strong, readonly) NSMutableArray<id<XcodeGroupMember>>* children;
 
 
 #pragma mark Initializers
 
-+ (XCGroup*)groupWithProject:(XCProject*)project key:(NSString*)key alias:(NSString*)alias path:(NSString*)path children:(NSArray*)children;
++ (XCGroup*)groupWithProject:(XCProject*)project key:(NSString*)key alias:(NSString*)alias path:(NSString*)path children:(NSArray<id<XcodeGroupMember>>*)children;
 
-- (id)initWithProject:(XCProject*)project key:(NSString*)key alias:(NSString*)alias path:(NSString*)path children:(NSArray*)children;
+- (id)initWithProject:(XCProject*)project key:(NSString*)key alias:(NSString*)alias path:(NSString*)path children:(NSArray<id<XcodeGroupMember>>*)children;
 
 #pragma mark Parent group
 
@@ -97,7 +98,7 @@
 /**
  * Adds a class to the group, making it a member of the specified [targets](XCTarget).
 */
-- (void)addClass:(XCClassDefinition*)classDefinition toTargets:(NSArray*)targets;
+- (void)addClass:(XCClassDefinition*)classDefinition toTargets:(NSArray<XCTarget*>*)targets;
 
 /**
 * Adds a framework to the group. If the group already contains the framework, the contents will be updated if the
@@ -118,7 +119,7 @@
 /**
 * Adds a framework to the group, making it a member of the specified targets.
 */
-- (void)addFramework:(XCFrameworkDefinition*)framework toTargets:(NSArray*)targets;
+- (void)addFramework:(XCFrameworkDefinition*)framework toTargets:(NSArray<XCTarget*>*)targets;
 
 /**
 * Adds a source file of arbitrary type - image resource, header, etc.
@@ -134,7 +135,7 @@
 /**
  * Adds a xib to the group, making it a member of the specified [targets](XCTarget).
 */
-- (void)addXib:(XCXibDefinition*)xibDefinition toTargets:(NSArray*)targets;
+- (void)addXib:(XCXibDefinition*)xibDefinition toTargets:(NSArray<XCTarget*>*)targets;
 
 /**
  * Adds a sub-project to the group. If the group already contains a sub-project by the same name, the contents will be
@@ -147,26 +148,28 @@
 /**
 * Adds a sub-project to the group, making it a member of the specified [targets](XCTarget).
 */
-- (void)addSubProject:(XCSubProjectDefinition*)projectDefinition toTargets:(NSArray*)targets;
+- (void)addSubProject:(XCSubProjectDefinition*)projectDefinition toTargets:(NSArray<XCTarget*>*)targets;
 
 - (void)removeSubProject:(XCSubProjectDefinition*)projectDefinition;
 
-- (void)removeSubProject:(XCSubProjectDefinition*)projectDefinition fromTargets:(NSArray*)targets;
+- (void)removeSubProject:(XCSubProjectDefinition*)projectDefinition fromTargets:(NSArray<XCTarget*>*)targets;
 
 
 #pragma mark Locating children
 /**
  * Instances of `XCSourceFile` and `XCGroup` returned as the type `XcodeGroupMember`.
 */
-- (NSArray*)members;
+- (NSArray<id<XcodeGroupMember>>*)members;
 
 /**
-* Instances of `XCSourceFile` from this group and any child groups.
+* Keys of members from this group and any child groups.
 */
-- (NSArray*)recursiveMembers;
+- (NSArray<NSString*>*)recursiveMembers;
 
-
-- (NSArray*)buildFileKeys;
+/**
+ * Keys of members from this group
+ */
+- (NSArray<NSString*>*)buildFileKeys;
 
 /**
  * Returns the child with the specified key, or nil.

--- a/Source/XCGroup.m
+++ b/Source/XCGroup.m
@@ -355,7 +355,7 @@
 //-------------------------------------------------------------------------------------------
 #pragma mark Members
 
-- (NSArray*)members
+- (NSArray<id<XcodeGroupMember>>*)members
 {
     if (_members == nil)
     {

--- a/Source/XCProject+SubProject.h
+++ b/Source/XCProject+SubProject.h
@@ -19,11 +19,11 @@
 
 - (NSString *)referenceProxyKeyForName:(NSString *)name;
 
-- (NSArray *)buildProductsForTargets:(NSString *)xcodeprojKey;
+- (NSArray<XCSourceFile*> *)buildProductsForTargets:(NSString *)xcodeprojKey;
 
-- (void)addAsTargetDependency:(XCSubProjectDefinition *)xcodeprojDefinition toTargets:(NSArray *)targets;
+- (void)addAsTargetDependency:(XCSubProjectDefinition *)xcodeprojDefinition toTargets:(NSArray<XCTarget*>*)targets;
 
-- (NSArray *)keysForProjectObjectsOfType:(XcodeMemberType)memberType withIdentifier:(NSString *)identifier
+- (NSArray<NSString*> *)keysForProjectObjectsOfType:(XcodeMemberType)memberType withIdentifier:(NSString *)identifier
     singleton:(BOOL)singleton required:(BOOL)required;
 
 - (NSMutableDictionary *)PBXProjectDict;

--- a/Source/XCProject.h
+++ b/Source/XCProject.h
@@ -58,7 +58,7 @@ NSString* const XCProjectNotFoundException;
 /**
 * Returns all file resources in the project, as an array of `XCSourceFile` objects.
 */
-- (NSArray*)files;
+- (NSArray<XCSourceFile*>*)files;
 
 /**
 * Returns the project file with the specified key, or nil.
@@ -74,24 +74,24 @@ NSString* const XCProjectNotFoundException;
 /**
 * Returns all header files in the project, as an array of `XCSourceFile` objects.
 */
-- (NSArray*)headerFiles;
+- (NSArray<XCSourceFile*>*)headerFiles;
 
 /**
 * Returns all implementation obj-c implementation files in the project, as an array of `XCSourceFile` objects.
 */
-- (NSArray*)objectiveCFiles;
+- (NSArray<XCSourceFile*>*)objectiveCFiles;
 
 /**
 * Returns all implementation obj-c++ implementation files in the project, as an array of `XCSourceFile` objects.
 */
-- (NSArray*)objectiveCPlusPlusFiles;
+- (NSArray<XCSourceFile*>*)objectiveCPlusPlusFiles;
 
 /**
 * Returns all the xib files in the project, as an array of `XCSourceFile` objects.
 */
-- (NSArray*)xibFiles;
+- (NSArray<XCSourceFile*>*)xibFiles;
 
-- (NSArray*)imagePNGFiles;
+- (NSArray<XCSourceFile*>*)imagePNGFiles;
 
 - (NSString*)filePath;
 
@@ -101,7 +101,7 @@ NSString* const XCProjectNotFoundException;
 /**
 * Lists the groups in an xcode project, returning an array of `XCGroup` objects.
 */
-- (NSArray*)groups;
+- (NSArray<XCGroup*>*)groups;
 
 /**
  * Returns the root (top-level) group.
@@ -111,7 +111,7 @@ NSString* const XCProjectNotFoundException;
 /**
  * Returns the root (top-level) groups, if there are multiple. An array of rootGroup if there is only one.
  */
-- (NSArray*)rootGroups;
+- (NSArray<XCGroup*>*)rootGroups;
 
 /**
 * Returns the group with the given key, or nil.
@@ -138,7 +138,7 @@ NSString* const XCProjectNotFoundException;
 /**
 * Lists the targets in an xcode project, returning an array of `XCTarget` objects.
 */
-- (NSArray*)targets;
+- (NSArray<XCTarget*>*)targets;
 
 /**
 * Returns the target with the specified name, or nil. 
@@ -146,13 +146,14 @@ NSString* const XCProjectNotFoundException;
 - (XCTarget*)targetWithName:(NSString*)name;
 
 #pragma mark Configurations
-
 /**
-* Returns the target with the specified name, or nil. 
-*/
-- (NSDictionary*)configurations;
-
-- (NSDictionary*)configurationWithName:(NSString*)name;
+ * Lists the configurations in an xcode project.
+ */
+- (NSDictionary<NSString*,XCProjectBuildConfig*>*)configurations;
+/**
+ * Returns the configuration with the specified name, or nil.
+ */
+- (XCProjectBuildConfig*)configurationWithName:(NSString*)name;
 
 - (XCProjectBuildConfig *)defaultConfiguration;
 

--- a/Source/XCProject.m
+++ b/Source/XCProject.m
@@ -365,7 +365,7 @@
     return [_configurations copy];
 }
 
-- (NSDictionary*)configurationWithName:(NSString*)name
+- (XCProjectBuildConfig*)configurationWithName:(NSString*)name
 {
     return [[self configurations] objectForKey:name];
 }

--- a/Source/XCProjectBuildConfig.h
+++ b/Source/XCProjectBuildConfig.h
@@ -25,7 +25,7 @@
 
 @property(nonatomic, readonly) NSDictionary* specifiedBuildSettings;
 
-+ (NSDictionary*)buildConfigurationsFromArray:(NSArray*)array inProject:(XCProject*)project;
++ (NSDictionary<NSString*,NSString*>*)buildConfigurationsFromArray:(NSArray<XCProjectBuildConfig*>*)array inProject:(XCProject*)project;
 
 - (instancetype)initWithProject:(XCProject*)project key:(NSString*)key;
 

--- a/Source/XCSubProjectDefinition.h
+++ b/Source/XCSubProjectDefinition.h
@@ -48,7 +48,7 @@
 
 - (NSString *)fullPathName;
 
-- (NSArray *)buildProductNames;
+- (NSArray<NSString*> *)buildProductNames;
 
 - (NSString *)projectKey;
 

--- a/Source/XCTarget.h
+++ b/Source/XCTarget.h
@@ -46,11 +46,11 @@
 - (id)initWithProject:(XCProject*)project key:(NSString*)key name:(NSString*)name productName:(NSString*)productName
     productReference:(NSString*)productReference;
 
-- (NSArray*)resources;
+- (NSArray<XCSourceFile*>*)resources;
 
-- (NSArray*)members;
+- (NSArray<XCSourceFile*>*)members;
 
-- (NSDictionary*)configurations;
+- (NSDictionary<NSString*,XCProjectBuildConfig*>*)configurations;
 
 - (XCProjectBuildConfig *)configurationWithName:(NSString*)name;
 
@@ -60,7 +60,7 @@
 
 - (void)removeMemberWithKey:(NSString*)key;
 
-- (void)removeMembersWithKeys:(NSArray*)keys;
+- (void)removeMembersWithKeys:(NSArray<NSString*>*)keys;
 
 - (void)addDependency:(NSString*)key;
 


### PR DESCRIPTION
This PR adds Xcode 7 lightweight generic annotations to various .h files. This makes the library much more pleasant to use in Swift and also adds some compiler checking (during the process I discovered that `-[XCProject configurationWithName]` had an incorrect return type!)

I did not propagate the annotated types to the .m files since it appears the compiler ignores them (e.g. you can add a different annotation in the .m file and the compiler and static analyzer do not complain).

Since these annotations are only available in Xcode 7 perhaps they should not be merged onto master? It would break builds for folks still on Xcode 6.