### PR TITLE
Moved global variable declaration from .h to .m file

### DIFF
--- a/Source/XCProject.h
+++ b/Source/XCProject.h
@@ -21,8 +21,6 @@
 @class XCSubProjectDefinition;
 @class XCProjectBuildConfig;
 
-NSString* const XCProjectNotFoundException;
-
 @interface XCProject : NSObject
 {
 @protected

--- a/Source/XCProject.m
+++ b/Source/XCProject.m
@@ -17,6 +17,8 @@
 #import "XCFileOperationQueue.h"
 #import "XCProjectBuildConfig.h"
 
+NSString* const XCProjectNotFoundException;
+
 
 @implementation XCProject
 


### PR DESCRIPTION
This fixes "duplicated symbol" linker errors for XCProjectNotFoundException, occurring because XCProject.h file was included in several .m files.