### PR TITLE
Several Enhancements/Bug fixes

### DIFF
--- a/Source/XCGroup.h
+++ b/Source/XCGroup.h
@@ -12,6 +12,7 @@
 
 #import <Foundation/Foundation.h>
 #import "XcodeGroupMember.h"
+#import "XcodeSourceFileType.h"
 
 @class XCProject;
 @class XCClassDefinition;
@@ -117,6 +118,8 @@
 * Adds a reference to a folder
 */
 - (void)addFolderReference:(NSString*)sourceFolder;
+
+- (void)addFileReference:(NSString *)filePath withType:(XcodeSourceFileType)type;
 
 /**
 * Adds a framework to the _group, making it a member of the specified targets.

--- a/Source/XCGroup.m
+++ b/Source/XCGroup.m
@@ -192,6 +192,15 @@
     [_project objects][_key] = [self asDictionary];
 }
 
+- (void)addFileReference:(NSString *)filePath withType:(XcodeSourceFileType)type
+{
+    NSDictionary *folderReferenceDictionary =
+    [self makeFileReferenceWithPath:filePath name:[filePath lastPathComponent] type:type];
+    NSString *folderReferenceKey = [[XCKeyBuilder forItemNamed:[filePath lastPathComponent]] build];
+    [self addMemberWithKey:folderReferenceKey];
+    [_project objects][folderReferenceKey] = folderReferenceDictionary;
+    [_project objects][_key] = [self asDictionary];
+}
 
 - (XCGroup *)addGroupWithPath:(NSString *)path
 {

--- a/Source/XCProject.m
+++ b/Source/XCProject.m
@@ -305,6 +305,9 @@ NSString *const XCProjectNotFoundException;
 {
     [_fileOperationQueue commitFileOperations];
     [_dataStore writeToFile:[_filePath stringByAppendingPathComponent:@"project.pbxproj"] atomically:YES];
+    
+    // Don't forget to reset the cache so that we'll always get the latest data.
+    [self dropCache];
 
     NSLog(@"Saved project");
 }

--- a/Source/XCProjectBuildConfig.m
+++ b/Source/XCProjectBuildConfig.m
@@ -145,15 +145,10 @@
     NSDictionary* settings = [NSDictionary dictionaryWithObject:setting forKey:key];
     [self addBuildSettings:settings];
 
-    NSLog(@"$$$$$$$$$$$ before: %@", [_project.objects objectForKey:_key]);
-
     NSMutableDictionary* dict = [[[_project objects] objectForKey:_key] mutableCopy];
     [dict setValue:_buildSettings forKey:@"buildSettings"];
     [_project.objects setValue:dict forKey:_key];
-
-    NSLog(@"The settings: %@", [_project.objects objectForKey:_key]);
-
-    }
+}
 
 
 - (id <NSCopying>)valueForKey:(NSString*)key

--- a/Source/XCSourceFile.m
+++ b/Source/XCSourceFile.m
@@ -114,7 +114,7 @@
 
 - (BOOL)canBecomeBuildFile
 {
-    return _type == SourceCodeObjC || _type == SourceCodeObjCPlusPlus || _type == SourceCodeCPlusPlus || _type == XibFile || _type == Framework || _type == ImageResourcePNG || _type == HTML || _type == Bundle || _type == Archive || _type == AssetCatalog || _type == SourceCodeSwift;
+    return _type == SourceCodeObjC || _type == SourceCodeObjCPlusPlus || _type == SourceCodeCPlusPlus || _type == XibFile || _type == Framework || _type == ImageResourcePNG || _type == HTML || _type == Bundle || _type == Archive || _type == AssetCatalog || _type == SourceCodeSwift || _type == PropertyList;
 }
 
 
@@ -126,7 +126,7 @@
     else if (_type == Framework) {
         return PBXFrameworksBuildPhaseType;
     }
-    else if (_type == ImageResourcePNG || _type == HTML || _type == Bundle || _type == AssetCatalog) {
+    else if (_type == ImageResourcePNG || _type == HTML || _type == Bundle || _type == AssetCatalog || _type == PropertyList) {
         return PBXResourcesBuildPhaseType;
     }
     else if (_type == Archive) {

--- a/Source/XCTarget.h
+++ b/Source/XCTarget.h
@@ -62,6 +62,10 @@
 
 - (void)removeMembersWithKeys:(NSArray<NSString*>*)keys;
 
+- (void)removeResourceWithKey:(NSString*)key;
+
+- (void)removeResourcesWithKeys:(NSArray<NSString*>*)keys;
+
 - (void)addDependency:(NSString*)key;
 
 - (instancetype)duplicateWithTargetName:(NSString*)targetName productName:(NSString*)productName;


### PR DESCRIPTION
Sorry to merge several things in a single pull request.
There're three main things that has been done in this pull request:

- Now you can remove resource from XCTarget. (You can only add before)
- Now you can add property list to a target as a target member.
- Fixed a bug so that the XCProject will clean its cached data once it's saved. (For instance, after a new target is created.)