### PR TITLE
Performance improvement when looking up project groups repeatedly.

### DIFF
--- a/Source/XCProject.h
+++ b/Source/XCProject.h
@@ -187,5 +187,5 @@
 - (NSMutableDictionary*)dataStore;
 
 - (void)dropCache;
-
+- (void)dropGroupsCache;
 @end

--- a/Source/XCProject.m
+++ b/Source/XCProject.m
@@ -19,7 +19,9 @@
 
 NSString *const XCProjectNotFoundException;
 
-@implementation XCProject
+@implementation XCProject {
+    NSArray *_cachedGroups;
+}
 
 
 @synthesize fileOperationQueue = _fileOperationQueue;
@@ -149,6 +151,9 @@ NSString *const XCProjectNotFoundException;
 
 - (NSArray *)groups
 {
+    if (_cachedGroups) {
+        return _cachedGroups;
+    }
     NSMutableArray *results = [[NSMutableArray alloc] init];
     [[self objects] enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSDictionary *obj, BOOL *stop) {
         if ([[obj valueForKey:@"isa"] xce_hasGroupType]) {
@@ -160,6 +165,7 @@ NSString *const XCProjectNotFoundException;
             [results addObject:group];
         }
     }];
+    _cachedGroups = results;
     return results;
 }
 
@@ -314,6 +320,8 @@ NSString *const XCProjectNotFoundException;
 
 - (NSMutableDictionary *)objects
 {
+    // Purge groups cache in case something is getting changed.
+    [self dropGroupsCache];
     return [_dataStore objectForKey:@"objects"];
 }
 
@@ -327,6 +335,11 @@ NSString *const XCProjectNotFoundException;
     _targets = nil;
     _configurations = nil;
     _rootObjectKey = nil;
+}
+
+- (void)dropGroupsCache
+{
+    _cachedGroups = nil;
 }
 
 


### PR DESCRIPTION
For example, this substantially improves performance when looking up paths for all files in a project.